### PR TITLE
Rewrite getRefundAmountCopy method to remove concatinations

### DIFF
--- a/force-app/main/default/lwc/tripAssistAppCancel/tripAssistAppCancel.js
+++ b/force-app/main/default/lwc/tripAssistAppCancel/tripAssistAppCancel.js
@@ -168,7 +168,7 @@ export default class TripAssistAppCancel extends handleErrorMixin(LightningEleme
         this.isLoading = true;
         APEX_cancelBooking({
             bookingId: this.recordId,
-            cancellationFault: this.form.reason ? this.form.reason : "Traveler: Change In Plans",
+            cancellationFault: this.form.reason ? this.form.reason : DEFAULT_REASONS.GUEST,
             responsibleValue: this.responsibleValue,
             isFullProcess
         })

--- a/force-app/main/default/lwc/tripAssistUtils/tripAssistUtils.js
+++ b/force-app/main/default/lwc/tripAssistUtils/tripAssistUtils.js
@@ -81,14 +81,18 @@ export const navigateToTripAssistMixin = LWC => class extends NavigationMixin(ha
 // refund wrapper interface
 
 export const getRefundAmountCopy = (cash, ftc) => {
-    if (!cash && !ftc) return 'If cancelled now, the guest will be nothing refunded or issued.';
+    let refundCopy
+    if (!cash && !ftc){
+        refundCopy = 'will be nothing refunded or issued';
+    } else {
+        refundCopy = [
+            cash && `will be refunded <b>${format(CURRENCY_FORMAT, cash)}</b> to the <b>credit card</b> on file`,
+            ftc && `will be issued <b>${format(CURRENCY_FORMAT, ftc)}</b> in <b>FTC</b>`
+        ].filter(t => !!t)
+        .join(' and ')
+    } 
 
-    return 'If cancelled now, the guest '+
-    [
-        cash && `will be refunded <b>${format(CURRENCY_FORMAT, cash)}</b> to the <b>credit card</b> on file`,
-        ftc && `will be issued <b>${format(CURRENCY_FORMAT, ftc)}</b> in <b>FTC</b>`
-    ].filter(t => !!t).join(' and ')
-    +'.';
+    return `If cancelled now, the guest ${refundCopy}.`
 }
 export const getRefundTypeCopy = rules => {
     let copy = 'This booking is not eligible for a refund or FTC.';


### PR DESCRIPTION
Replace some text copies with contants.